### PR TITLE
revised format_estimates to work with non psrc counties

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
 	rlang,
 	sf,
 	leaflet,
-	htmltools
+	htmltools,
+	stringr
 Suggests: 
     rmarkdown,
     knitr,

--- a/R/format-estimates.R
+++ b/R/format-estimates.R
@@ -18,12 +18,19 @@
 #' Sys.getenv("CENSUS_API_KEY")
 #' df <- psrccensus::get_acs_recs(geography = 'county',
 #'                                table.names = c('B03002'),
-#'                                years=c(2019),
+#'                                years = c(2019),
 #'                                acs.type = 'acs1')
 #'
 #' format_estimates(df)
-#'
 #' format_estimates(df, type = 'share', moe = FALSE)
+#'
+#' t <- get_acs_recs(geography = 'county',
+#'                   counties = c("King", "Kitsap"),
+#'                   table.names = c('B03002'),
+#'                   years = c(2019),
+#'                   acs.type = 'acs1')
+#'
+#' format_estimates(t, type = 'share', moe = TRUE)
 #' @export
 format_estimates <- function(table, type = 'total', moe = TRUE){
 
@@ -74,8 +81,14 @@ format_estimates <- function(table, type = 'total', moe = TRUE){
   sort.cols <- setdiff(colnames(adf), c('variable', 'label', 'concept', 'acs_type', 'year'))
   new.col.order <- c(c('variable', 'label', 'concept', 'acs_type', 'year'), sort(sort.cols))
   adf <- adf %>%
-    dplyr::select(dplyr::all_of(new.col.order)) %>%
+    dplyr::select(dplyr::all_of(new.col.order))
+
+  region.col <- stringr::str_subset(colnames(adf), "^Region")
+
+  if(!is.null(region.col)) {
+  adf <- adf %>%
     dplyr::relocate(dplyr::starts_with('Region'), .after = dplyr::last_col())
+  }
 
   return(adf)
 }

--- a/man/format_estimates.Rd
+++ b/man/format_estimates.Rd
@@ -24,12 +24,19 @@ Format estimates of a county summary table with the option to include shares and
 Sys.getenv("CENSUS_API_KEY")
 df <- psrccensus::get_acs_recs(geography = 'county',
                                table.names = c('B03002'),
-                               years=c(2019),
+                               years = c(2019),
                                acs.type = 'acs1')
 
 format_estimates(df)
-
 format_estimates(df, type = 'share', moe = FALSE)
+
+t <- get_acs_recs(geography = 'county',
+                  counties = c("King", "Kitsap"),
+                  table.names = c('B03002'),
+                  years = c(2019),
+                  acs.type = 'acs1')
+
+format_estimates(t, type = 'share', moe = TRUE)
 }
 \author{
 Christy Lam


### PR DESCRIPTION
flexibility in `format_estimates()` to work with county-level tables that don't cover the PSRC region. Original code expected columns starting with `Region` (default output from `get_acs_recs()`)